### PR TITLE
styled service provider feedback page, added links, fixed bug in add feedback form

### DIFF
--- a/handyapp/src/components/HomeOwners/AddFeedbackForm.js
+++ b/handyapp/src/components/HomeOwners/AddFeedbackForm.js
@@ -9,7 +9,7 @@ class AddFeedbackForm extends Component {
         title: '',
         description: '',
         reviewer_name: '',
-        contractor_id:'',
+        contractor_id:props.id,
         recommend:'',
         rating:'',
 
@@ -29,8 +29,6 @@ class AddFeedbackForm extends Component {
             <input type='text' onChange={this.handleChanges} value={this.state.description} placeholder='description'name='description' 
             />
             <input type='text'onChange={this.handleChanges} value={this.state.reviwer_name} placeholder='your name'name='reviewer_name'
-            />
-            <input type='number'onChange={this.handleChanges} value={this.state.contractor_id} placeholder='contractor_id'name='contractor_id' 
             />
             <input type='text'onChange={this.handleChanges} value={this.state.recommend} placeholder='would you recommend?'name='recommend'
             />

--- a/handyapp/src/components/HomeOwners/Feedback.js
+++ b/handyapp/src/components/HomeOwners/Feedback.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 const Feedback = props =>{
     return(
-        <div>
+        <div className='Bid'>
             <p>Reviewer: {props.review.reviewer_name}</p>
             <p>Title: {props.review.title}</p>
             <p>Description: {props.review.description}</p>

--- a/handyapp/src/components/HomeOwners/ServiceProviderFeedback.css
+++ b/handyapp/src/components/HomeOwners/ServiceProviderFeedback.css
@@ -1,0 +1,70 @@
+.Project {
+    max-width: 90%;
+    height: 375px;
+    display: flex;
+    justify-content: space-between;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 12px 20px rgba(128, 128, 128, 0.28);
+    margin-bottom: 34px;
+  }
+  
+  .Project .project-image {
+    width: 448px;
+    height: 375px;
+    background: url('../../img/Placeholder-image.png') no-repeat center
+      center/cover;
+    border-radius: 4px 0 0 4px;
+  }
+  
+  .Project .project-image img {
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 4px 0 0 4px;
+  }
+  
+  .Project .project-content {
+    width: 70%;
+    padding: 84px 54px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+  }
+  
+  .Project .project-content .project-info {
+    color: #464646;
+  }
+  
+  .Project .project-content .project-info h2 {
+    font-size: 28px;
+    color: #000;
+    font-weight: 700;
+  }
+  
+  .Project .project-content .project-info i {
+    margin-right: 13px;
+  }
+  
+  .Project .project-content .description {
+    width: 100%;
+    border-top: 1px solid #f0f0f0;
+    color: #686868;
+    font-weight: 300;
+    line-height: 1.5;
+  }
+  .bid-container{
+      display:flex;
+      flex-direction:column;
+      justify-content:space-around;
+      padding-bottom:20px;
+  }
+  
+  .Bid{
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 12px 20px rgba(128, 128, 128, 0.28);
+    margin-bottom:30px;
+    width:90%;
+
+  }

--- a/handyapp/src/components/HomeOwners/ServiceProviderFeedback.js
+++ b/handyapp/src/components/HomeOwners/ServiceProviderFeedback.js
@@ -4,13 +4,16 @@ import Feedback from './Feedback';
 import {getFeedbackByContractorId} from '../../actions';
 import AddFeedbackForm from './AddFeedbackForm';
 
+import './ServiceProviderFeedback.css'
+
 class ServiceProviderFeedback extends Component {
   componentDidMount() {
     const id=this.props.match.params.id
+    console.log(this.props.match.params.id)
     this.props.getFeedbackByContractorId(id);
   }
   
-
+ 
   render() {
     if (this.props.feedback.reviews === undefined) {
       return (
@@ -18,23 +21,36 @@ class ServiceProviderFeedback extends Component {
           <h4>Loading...</h4>
         </>
       );
-    } else {
+    } else if(this.props.feedback.reviews=== null) {
+      return(
+        <h2>Problem getting Contractor at this time</h2>
+      );
+    }else{
     console.log(this.props.feedback.reviews);
       return (
         <div className="project-container">
-          <h1>Contrator Details</h1>
+        <div className="Project">
+        <div className="project-image">
+        <img src={this.props.feedback.avatar ? this.props.feedback.avatar : ''} alt="" />
+      </div>
+          <div className='project-content'>
+          <div className='project-info'>
           <h2>{this.props.feedback.first_name} {this.props.feedback.last_name}</h2>
+          </div>
           <h4>{this.props.feedback.address}</h4>
           <h4>{this.props.feedback.phone_number}</h4>
           <h4>{this.props.feedback.licenses}</h4>
           <h4>{this.props.feedback.experience}</h4>
           <h4>{this.props.feedback.skills}</h4>
-          <div>
+          </div>
+          </div>
+          <div className='bid-container'>
             {this.props.feedback.reviews.map(review =>(
               <Feedback review={review} key={review.id}/>
             ))}
           </div>
-          <AddFeedbackForm />
+          <AddFeedbackForm id={this.props.match.params.id}/>
+        
         </div>
       );
     }

--- a/handyapp/src/components/Projects/BidsForProject.js
+++ b/handyapp/src/components/Projects/BidsForProject.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Link} from 'react-router-dom'
 
  const BidsForProject = props => {
   return (
@@ -8,8 +9,12 @@ import React from 'react';
       <p>Hours:{props.bid.time}</p>
       <p>Materials included? {props.bid.materials_included}</p>
       <div className='buttons'>
+      <Link to ={'/checkout'} >
       <button>Accept Bid</button>
+      </Link>
+      <Link to={`/contractor/${props.bid.contractor_id}`}>
       <button>View Contractor</button>
+      </Link>
       </div>
     </div>
   );


### PR DESCRIPTION


# Description
Creates styles for service provider feedback page to match handyapp theme, also adds links to checkout, and view provider from project by id, Also fixes bug so contractor_id doesn't have to be manually imput on feedback form
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
# How Has This Been Tested?

- [x] Test A- Tested locally on localhost

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
